### PR TITLE
[58] Cleanup task

### DIFF
--- a/lib/deploy_pin.rb
+++ b/lib/deploy_pin.rb
@@ -15,6 +15,7 @@ require 'colorize'
 
 module DeployPin
   OPTIONS = %i[
+    cleanup_safe_time_window
     deployment_state_transition
     fallback_group
     groups
@@ -26,6 +27,7 @@ module DeployPin
   ].freeze
 
   DEFAULTS = {
+    cleanup_safe_time_window: -> { 1.year },
     task_wrapper: ->(_task, task_runner) { task_runner.call }
   }.freeze
 

--- a/lib/deploy_pin/collector.rb
+++ b/lib/deploy_pin/collector.rb
@@ -26,6 +26,10 @@ module DeployPin
       end
     end
 
+    def cleanup
+      init_tasks.select(&:classified_for_cleanup?).each(&:remove)
+    end
+
     def executable
       # cache tasks
       tasks = init_tasks

--- a/lib/deploy_pin/runner.rb
+++ b/lib/deploy_pin/runner.rb
@@ -11,6 +11,10 @@ module DeployPin
       DeployPin::Collector.new(identifiers:).list
     end
 
+    def self.cleanup(identifiers:)
+      DeployPin::Collector.new(identifiers:).cleanup
+    end
+
     def self.summary(identifiers:)
       # print summary
       self.print('======= Summary ========')

--- a/lib/deploy_pin/task.rb
+++ b/lib/deploy_pin/task.rb
@@ -31,6 +31,11 @@ module DeployPin
       eval(script)
     end
 
+    def remove
+      File.delete(file) if File.exist?(file)
+      record&.destroy
+    end
+
     def record
       DeployPin::Record.find_by(uuid: identifier)
     end
@@ -69,6 +74,12 @@ module DeployPin
 
     def under_timeout?
       !explicit_timeout? && !parallel?
+    end
+
+    def classified_for_cleanup?
+      return false unless done?
+
+      record.completed_at < DeployPin.cleanup_safe_time_window.call.ago
     end
 
     def parse

--- a/lib/tasks/deploy_pin_tasks.rake
+++ b/lib/tasks/deploy_pin_tasks.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :deploy_pin do
-  desc 'run pending tasks'
+  desc 'Run pending tasks'
   task :run, [:identifiers] => :environment do |_t, args|
     identifiers = args.identifiers
     attributes = identifiers.nil? ? DeployPin.groups : identifiers.split(/\s*,\s*/)
@@ -9,6 +9,7 @@ namespace :deploy_pin do
     DeployPin::Runner.run(identifiers: attributes)
   end
 
+  desc 'List defined tasks'
   task :list, [:identifiers] => :environment do |_t, args|
     args.with_defaults(identifiers: DeployPin.groups)
 

--- a/lib/tasks/deploy_pin_tasks.rake
+++ b/lib/tasks/deploy_pin_tasks.rake
@@ -15,4 +15,11 @@ namespace :deploy_pin do
     DeployPin::Runner.list(**args)
     DeployPin::Runner.summary(**args)
   end
+
+  desc 'Remove tasks codebase and DB records for a defined time window'
+  task cleanup: :environment do
+    args.with_defaults(identifiers: DeployPin.groups)
+
+    DeployPin::Runner.cleanup(**args)
+  end
 end

--- a/test/lib/deploy_pin/runner_test.rb
+++ b/test/lib/deploy_pin/runner_test.rb
@@ -10,7 +10,7 @@ class DeployPin::Runner::Test < ActiveSupport::TestCase
     ::FileUtils.cp 'test/support/files/task_same.rb', "#{DeployPin.tasks_path}3_task.rb"
   end
 
-  test 'sumary' do
+  test 'summary' do
     assert_nothing_raised do
       DeployPin::Runner.summary(identifiers: [DeployPin.fallback_group])
     end

--- a/test/lib/deploy_pin/runner_test.rb
+++ b/test/lib/deploy_pin/runner_test.rb
@@ -33,4 +33,10 @@ class DeployPin::Runner::Test < ActiveSupport::TestCase
       DeployPin::Runner.list(identifiers: [DeployPin.fallback_group])
     end
   end
+
+  test 'cleanup' do
+    assert_nothing_raised do
+      DeployPin::Runner.cleanup(identifiers: DeployPin.groups)
+    end
+  end
 end

--- a/test/lib/deploy_pin/task_test.rb
+++ b/test/lib/deploy_pin/task_test.rb
@@ -12,9 +12,9 @@ class DeployPin::Task::Test < ActiveSupport::TestCase
   end
 
   test 'prepare' do
-    assert_equal DeployPin::Record.where(uuid: @task.identifier).count, 0
-    assert_nothing_raised { @task.prepare }
-    assert_equal DeployPin::Record.where(uuid: @task.identifier).count, 1
+    assert_difference 'DeployPin::Record.count', 1 do
+      assert_nothing_raised { @task.prepare }
+    end
   end
 
   test 'mark' do
@@ -25,9 +25,9 @@ class DeployPin::Task::Test < ActiveSupport::TestCase
   test 'done?' do
     @task.prepare
     assert_nothing_raised { @task.done? }
-    assert_equal @task.done?, false
+    refute @task.done?
     @task.mark
-    assert_equal @task.done?, true
+    assert @task.done?
   end
 
   test 'increment_progress!' do
@@ -74,24 +74,24 @@ class DeployPin::Task::Test < ActiveSupport::TestCase
 
   test 'explicit_timeout?' do
     @task.parse
-    assert_equal @task.send(:explicit_timeout?), false
+    refute @task.send(:explicit_timeout?)
 
     task_with_timeout = DeployPin::Task.new('test/support/files/task_with_timeout.rb')
     task_with_timeout.parse
-    assert_equal task_with_timeout.send(:explicit_timeout?), true
+    assert task_with_timeout.send(:explicit_timeout?)
   end
 
   test 'under_timeout?' do
     @task.parse
-    assert_equal @task.under_timeout?, true
+    assert @task.under_timeout?
 
     task_with_timeout = DeployPin::Task.new('test/support/files/task_with_timeout.rb')
     task_with_timeout.parse
-    assert_equal task_with_timeout.under_timeout?, false
+    refute task_with_timeout.under_timeout?
 
     parallel_task = DeployPin::Task.new('test/support/files/parallel_task.rb')
     parallel_task.parse
-    assert_equal parallel_task.under_timeout?, false
+    refute parallel_task.under_timeout?
   end
 
   test 'classified_for_cleanup?' do

--- a/test/lib/deploy_pin/task_test.rb
+++ b/test/lib/deploy_pin/task_test.rb
@@ -4,7 +4,9 @@ require 'test_helper'
 
 class DeployPin::Task::Test < ActiveSupport::TestCase
   setup do
-    @task = DeployPin::Task.new('test/support/files/task.rb')
+    @task_file = "#{DeployPin.tasks_path}1_task.rb"
+    ::FileUtils.cp 'test/support/files/task.rb', @task_file
+    @task = DeployPin::Task.new(@task_file)
   end
 
   test 'run' do
@@ -68,7 +70,7 @@ class DeployPin::Task::Test < ActiveSupport::TestCase
 
   test 'eql?' do
     assert_nothing_raised do
-      @task.eql?(DeployPin::Task.new('test/support/files/task.rb'))
+      @task.eql?(DeployPin::Task.new(@task_file))
     end
   end
 
@@ -113,7 +115,7 @@ class DeployPin::Task::Test < ActiveSupport::TestCase
 
   test '<=>' do
     assert_nothing_raised do
-      @task.send(:<=>, DeployPin::Task.new('test/support/files/task.rb'))
+      @task.send(:<=>, DeployPin::Task.new(@task_file))
     end
   end
 end


### PR DESCRIPTION
This pull request introduces a new cleanup feature to the `DeployPin` module, including methods for identifying and removing old tasks, as well as corresponding tests. The most important changes include:
* adding a cleanup time window
* implementing cleanup methods
* updating tests to cover the new functionality,
* improving already existing tests
* some smaller tweaks and fix for existing codebase
* adding a short documentation about the new feature to the `README.md` file