### PR TITLE
Add rake task `short_list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Check the documentation [here](lib/deploy_pin/parallel_wrapper.rb) for more deta
 
 ## Formatting
 
-`run_formatter` is used to format the output of a `run` task, and `list_formatter` is used to format the output of a `list` task. To set a default value, you should define it in the deploy_pin initializer:
+`run_formatter` is used to format the output of a `run` task, `list_formatter` for the `list` task and `list_short_formatter` is used to format the output of a `short_list` task. To set a default value, you should define it in the deploy_pin initializer:
 
 ```ruby
 # config/initializers/deploy_pin.rb
@@ -169,6 +169,23 @@ DeployPin.setup do
       end
 
       puts("\n<<<\n#{task.script.strip.green}\n>>>\n\n")
+    end
+  )
+  short_list_formatter(
+    lambda do |group, tasks, start_index|
+      puts(" Group: #{group} ".center(38, "=").light_cyan.bold)
+      puts("\n")
+
+      tasks.each.with_index(start_index) do |task, index|
+        puts(" Task ##{index} ".center(38, "=").blue.bold)
+        # print details
+        task.details.each do |key, value|
+          key_aligned = "#{key}:".ljust(20)
+          puts("#{key_aligned}#{value}")
+        end
+
+        puts("\n")
+      end
     end
   )
 end

--- a/lib/deploy_pin.rb
+++ b/lib/deploy_pin.rb
@@ -19,6 +19,7 @@ module DeployPin
     fallback_group
     groups
     list_formatter
+    short_list_formatter
     run_formatter
     statement_timeout
     task_wrapper

--- a/lib/deploy_pin/collector.rb
+++ b/lib/deploy_pin/collector.rb
@@ -26,6 +26,14 @@ module DeployPin
       end
     end
 
+    def short_list
+      groups_tasks = init_tasks.group_by(&:group).to_a
+      groups_tasks.inject(0) do |offset, (group, tasks)|
+        DeployPin.short_list_formatter.call(group, tasks, offset)
+        offset + tasks.count
+      end
+    end
+
     def executable
       # cache tasks
       tasks = init_tasks

--- a/lib/deploy_pin/runner.rb
+++ b/lib/deploy_pin/runner.rb
@@ -11,6 +11,10 @@ module DeployPin
       DeployPin::Collector.new(identifiers:).list
     end
 
+    def self.short_list(identifiers:)
+      DeployPin::Collector.new(identifiers:).short_list
+    end
+
     def self.summary(identifiers:)
       # print summary
       self.print('======= Summary ========')

--- a/lib/deploy_pin/task.rb
+++ b/lib/deploy_pin/task.rb
@@ -10,6 +10,7 @@ module DeployPin
                 :identifier,
                 :group,
                 :title,
+                :affected_areas,
                 :script,
                 :recurring,
                 :explicit_timeout
@@ -21,6 +22,7 @@ module DeployPin
       @identifier = nil
       @group = nil
       @title = ''
+      @affected_areas = ''
       @script = ''
       @explicit_timeout = false
       @parallel = false
@@ -80,6 +82,8 @@ module DeployPin
           @recurring = Regexp.last_match(3)
         when /\A# task_title:(.+)/
           @title = Regexp.last_match(1).strip
+        when /\A# affected_areas:(.+)/
+          @affected_areas = Regexp.last_match(1).strip
         when /\A[^#].*/
           @script += line
 
@@ -101,7 +105,8 @@ module DeployPin
       {
         identifier:,
         group:,
-        title:
+        title:,
+        affected_areas:
       }
     end
 

--- a/lib/generators/deploy_pin/install/templates/deploy_pin.rb
+++ b/lib/generators/deploy_pin/install/templates/deploy_pin.rb
@@ -34,4 +34,21 @@ DeployPin.setup do
       puts("\n<<<\n#{task.script.strip.green}\n>>>\n\n")
     end
   )
+  short_list_formatter(
+    lambda do |group, tasks, start_index|
+      puts(" Group: #{group} ".center(38, "=").light_cyan.bold)
+      puts("\n")
+
+      tasks.each.with_index(start_index) do |task, index|
+        puts(" Task ##{index} ".center(38, "=").blue.bold)
+        # print details
+        task.details.each do |key, value|
+          key_aligned = "#{key}:".ljust(20)
+          puts("#{key_aligned}#{value}")
+        end
+
+        puts("\n")
+      end
+    end
+  )
 end

--- a/lib/tasks/deploy_pin_tasks.rake
+++ b/lib/tasks/deploy_pin_tasks.rake
@@ -15,4 +15,11 @@ namespace :deploy_pin do
     DeployPin::Runner.list(**args)
     DeployPin::Runner.summary(**args)
   end
+
+  task :short_list, [:identifiers] => :environment do |_t, args|
+    args.with_defaults(identifiers: DeployPin.groups)
+
+    DeployPin::Runner.short_list(**args)
+    DeployPin::Runner.summary(**args)
+  end
 end

--- a/test/dummy/config/initializers/deploy_pin.rb
+++ b/test/dummy/config/initializers/deploy_pin.rb
@@ -6,4 +6,5 @@ DeployPin.setup do
   fallback_group 'II'
   run_formatter ->(*) {}
   list_formatter ->(*) {}
+  short_list_formatter ->(*) {}
 end

--- a/test/lib/tasks/deploy_pin_tasks_test.rb
+++ b/test/lib/tasks/deploy_pin_tasks_test.rb
@@ -18,6 +18,18 @@ class DeployPinTasksTest < ActiveSupport::TestCase
     end
   end
 
+  test "deploy_pin:short_list'" do
+    assert_nothing_raised do
+      Rake::Task['deploy_pin:short_list'].invoke
+    end
+  end
+
+  test "deploy_pin:short_list[I]'" do
+    assert_nothing_raised do
+      Rake::Task['deploy_pin:short_list'].invoke('I')
+    end
+  end
+
   test "deploy_pin:run'" do
     assert_nothing_raised do
       Rake::Task['deploy_pin:run'].invoke


### PR DESCRIPTION
This pull request introduces a new rake task `short_list` to the DeployPin module. This task generates a concise list of tasks, organized into groups without task's code.

**Key Changes:**

- **New rake task** `short_list`: This task outputs a streamlined list of DeployPin tasks, grouped accordingly (refer to the screenshot).
- **Testing improvements**: Additional tests have been added to verify the successful execution of the `short_list` task.
- **Minor Updates**: The `list` task output now includes information about the affected areas.
- **Updated Documentation**: A `Formatting` section has been updated with the description of the functionality of the `short_list_formatter` for the `short_list` task.

![Screenshot from 2025-01-22 18-58-36](https://github.com/user-attachments/assets/a420c551-c836-47f5-976b-c400fc0c3cd4)
