### PR TITLE
Fix formatter name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Check the documentation [here](lib/deploy_pin/parallel_wrapper.rb) for more deta
 
 ## Formatting
 
-`run_formatter` is used to format the output of a `run` task, `list_formatter` for the `list` task and `list_short_formatter` is used to format the output of a `short_list` task. To set a default value, you should define it in the deploy_pin initializer:
+`run_formatter` is used to format the output of a `run` task, `list_formatter` for the `list` task and `short_list_formatter` is used to format the output of a `short_list` task. To set a default value, you should define it in the deploy_pin initializer:
 
 ```ruby
 # config/initializers/deploy_pin.rb


### PR DESCRIPTION
## Summary
- fix the documentation to reference `short_list_formatter`

## Testing
- `bundle exec rake test` *(fails: rbenv version `3.3.7` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b6461dbe4832785b3e5e4639dd1e5