### PR TITLE
Update CHANGELOG for v1.7.1-v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,13 @@
 you can store progress and continue the task from where it has stopped/crashed.
 
 !!!You should run `rails g deploy_pin:upgrade` to generate a migration file that will add the required columns to `deploy_pins` table.
+
+# 1.7.3 / 2025-01-23
+* Add `short_list` rake task for concise task listings.
+* Support Ruby on Rails 8 and update dependencies.
+
+# 1.7.2 / 2024-10-17
+* Add `save_progress!` method to store progress explicitly.
+
+# 1.7.1 / 2024-10-11
+* Mark existing deploy pins as completed during upgrade.


### PR DESCRIPTION
## Summary
- update CHANGELOG to include versions 1.7.1–1.7.3

## Testing
- `bundle exec rake test` *(fails: version `3.3.7` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b658051e88327b60374172f797a29