### PR TITLE
Fix minor README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ DeployPin.pending_deployment?
 
 Around the deployment
 ```bash
-bundle exec rake deploy_pin:run[I, II, III] - # enters to ongoing state before "I" and leaves it after "III" so all tasks in I, II, III have DeployPin.oingoing_deployment? == true
+bundle exec rake deploy_pin:run[I, II, III] - # enters to ongoing state before "I" and leaves it after "III" so all tasks in I, II, III have DeployPin.ongoing_deployment? == true
 bundle exec rake deploy_pin:run[rollback] - # enters "pending state"
 ```
 ## Similar Gems


### PR DESCRIPTION
## Summary
- fix a typo referring to `ongoing_deployment?` in README

## Testing
- `bundle exec rake -T | head -n 20` *(fails: rbenv version `3.3.7` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b657b5a708327b1de3b8398785992