### PR TITLE
[~] Validate deploy ping group to be present in groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.7.5 / 2025-06-13
+* Add validation for `group` attribute in task generation. Group should be present in the allowed groups list.
+
 # 1.7.4 / 2025-06-13
 * Change default affected areas
 * Add possibility to remove fallback_group from initializer and make `--group` attribute required on task generation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deploy_pin (1.7.4)
+    deploy_pin (1.7.5)
       colorize (~> 1.1)
       connection_pool (~> 2.2)
       parallel (~> 1.23)

--- a/lib/deploy_pin/version.rb
+++ b/lib/deploy_pin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeployPin
-  VERSION = '1.7.4'
+  VERSION = '1.7.5'
 end

--- a/lib/generators/deploy_pin/task/task_generator.rb
+++ b/lib/generators/deploy_pin/task/task_generator.rb
@@ -36,6 +36,10 @@ module DeployPin
 
     def validate
       raise Thor::Error, set_color('Missing required option: --group', :red) if options[:group].blank?
+
+      return if DeployPin.groups.include?(options[:group])
+
+      raise Thor::Error, set_color("Group '#{options[:group]}' is not defined in DeployPin.groups", :red)
     end
   end
 end

--- a/test/lib/generators/deploy_pin/task_generator_test.rb
+++ b/test/lib/generators/deploy_pin/task_generator_test.rb
@@ -14,6 +14,12 @@ class DeployPin::TaskGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test 'rases error if group is not present in allowed group' do
+    assert_raises(Thor::Error) do
+      DeployPin::TaskGenerator.new(['title'], { group: 'D' }, destination_root: destination_root)
+    end
+  end
+
   test 'generator runs without errors (with group)' do
     assert_nothing_raised do
       DeployPin::TaskGenerator.new(


### PR DESCRIPTION
Added validation for the `group` attribute in task generation. The group must be included in the allowed groups list.