### PR TITLE
[~] Add continue on error option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ coverage/*
 task.rb
 *.swp
 *.gem
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -257,6 +257,27 @@ Around the deployment
 bundle exec rake deploy_pin:run[I, II, III] - # enters to ongoing state before "I" and leaves it after "III" so all tasks in I, II, III have DeployPin.ongoing_deployment? == true
 bundle exec rake deploy_pin:run[rollback] - # enters "pending state"
 ```
+## Continue on Error
+
+By default, if a task raises an error, the entire deploy pin run is aborted. You can configure `continue_on_error` to rescue failures, log them, and still mark the task as done. This is useful in CI environments where external services may be unavailable.
+
+```ruby
+# config/initializers/deploy_pin.rb
+DeployPin.setup do
+  continue_on_error true
+end
+```
+
+Or conditionally via environment variable:
+
+```ruby
+DeployPin.setup do
+  continue_on_error ENV.fetch("DEPLOY_PIN_CONTINUE_ON_ERROR", "false") == "true"
+end
+```
+
+When enabled, failed tasks will log the error and continue to the next task without halting execution.
+
 ## Similar Gems
 - https://github.com/ilyakatz/data-migrate
 - https://github.com/Shopify/maintenance_tasks

--- a/lib/deploy_pin.rb
+++ b/lib/deploy_pin.rb
@@ -15,6 +15,7 @@ require 'colorize'
 
 module DeployPin
   OPTIONS = %i[
+    continue_on_error
     deployment_state_transition
     fallback_group
     groups
@@ -27,13 +28,14 @@ module DeployPin
   ].freeze
 
   DEFAULTS = {
+    continue_on_error: false,
     task_wrapper: ->(_task, task_runner) { task_runner.call }
   }.freeze
 
   OPTIONS.each do |option|
     instance_eval %{
       def #{option}(val = nil)
-        return @#{option} unless val.present?
+        return @#{option} if val.nil?
 
         @#{option} = val
       end

--- a/lib/deploy_pin/collector.rb
+++ b/lib/deploy_pin/collector.rb
@@ -68,7 +68,7 @@ module DeployPin
 
         # run if executable
         if executable
-          duration = execution_duration { run_with_timeout(task) { task.run } }
+          duration = execution_duration { run_task_safely(task) }
           DeployPin.run_formatter.call(index, tasks.count, task, executable, false, duration)
         end
 
@@ -76,6 +76,15 @@ module DeployPin
       end
       # :reek:TooManyStatements
       # :reek:FeatureEnvy
+
+      def run_task_safely(task)
+        run_with_timeout(task) { task.run }
+      rescue StandardError => e
+        raise unless DeployPin.continue_on_error
+
+        DeployPin::Runner.print("[DeployPin] Task #{task.identifier} failed: #{e.message}".red)
+        DeployPin::Runner.print('[DeployPin] Continuing due to continue_on_error configuration'.yellow)
+      end
 
       # :reek:UtilityFunction
       def files

--- a/test/lib/deploy_pin/collector_test.rb
+++ b/test/lib/deploy_pin/collector_test.rb
@@ -67,4 +67,46 @@ class DeployPin::Collector::Test < ActiveSupport::TestCase
 
     assert_output(/called\ncalled\n/) { @collector.run }
   end
+
+  test 'continue_on_error marks failed task as done and continues' do
+    # Setup with a failing task
+    ::FileUtils.rm_rf(DeployPin.tasks_path, secure: true)
+    ::FileUtils.mkdir(DeployPin.tasks_path)
+    ::FileUtils.cp 'test/support/files/failing_task.rb', "#{DeployPin.tasks_path}1_task.rb"
+    ::FileUtils.cp 'test/support/files/task.rb', "#{DeployPin.tasks_path}2_task.rb"
+
+    DeployPin.setup do
+      continue_on_error true
+    end
+
+    collector = DeployPin::Collector.new(identifiers: DeployPin.groups)
+
+    assert_nothing_raised do
+      collector.run
+    end
+
+    # Both tasks should be marked as done
+    assert DeployPin::Record.find_by(uuid: '75371573753799').completed_at.present?
+    assert DeployPin::Record.find_by(uuid: '75371573753751').completed_at.present?
+  ensure
+    DeployPin.setup do
+      continue_on_error false
+    end
+  end
+
+  test 'without continue_on_error raises on failed task' do
+    ::FileUtils.rm_rf(DeployPin.tasks_path, secure: true)
+    ::FileUtils.mkdir(DeployPin.tasks_path)
+    ::FileUtils.cp 'test/support/files/failing_task.rb', "#{DeployPin.tasks_path}1_task.rb"
+
+    DeployPin.setup do
+      continue_on_error false
+    end
+
+    collector = DeployPin::Collector.new(identifiers: DeployPin.groups)
+
+    assert_raises(RuntimeError) do
+      collector.run
+    end
+  end
 end

--- a/test/support/files/failing_task.rb
+++ b/test/support/files/failing_task.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# 75371573753799:I
+# task_title: failing task
+# affected_areas: none
+
+# === task code goes down here ===
+raise 'Something went wrong'


### PR DESCRIPTION
### Summary
- Add continue_on_error option that allows deploy pin tasks to be marked as done even when they fail due to runtime errors (e.g., unavailable external services)
- When enabled, failed tasks log a warning and continue execution instead of halting the entire deploy pin run
### Motivation
Some deploy pin tasks depend on external services that may not be available in all environments (e.g., CI workflows for dynamic env snapshot updates). Previously, if a task failed, the entire run would abort and subsequent tasks (and migrations) would not execute. With this option, tasks that fail are still marked as completed and execution proceeds, ensuring the deploy pin run always succeeds.
### Usage
```
DeployPin.setup do
  continue_on_error true
end
```
Or via environment variable in the consuming app's initializer:
`continue_on_error ENV.fetch("DEPLOY_PIN_CONTINUE_ON_ERROR", "false") == "true"`
### Changes
- lib/deploy_pin.rb — added continue_on_error to OPTIONS with default false
- lib/deploy_pin/collector.rb — extracted run_task_safely that rescues StandardError when continue_on_error is enabled, logs the error, and allows task.mark to still execute