### PR TITLE
Relax connection_pool dependency to unblock Sidekiq 8 upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.8.8 / 2026-07-11
+* Relax `connection_pool` dependency to `>= 2.2, < 5` (was `~> 2.2`). The previous pin blocked apps from upgrading to Sidekiq > 8.0.1, which requires `connection_pool >= 3.0`.
+
 # 1.7.6 / 2025-11-25
 # Add `rake deploy_pin:mark_done` task to mark specific deploy pins as completed based on criteria.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    deploy_pin (1.8.7)
+    deploy_pin (1.8.8)
       colorize (~> 1.1)
-      connection_pool (~> 2.2)
+      connection_pool (>= 2.2, < 5)
       parallel (~> 1.23)
       rails (>= 7.0, < 9.0)
       redis (> 4.0)
@@ -94,7 +94,7 @@ GEM
     coderay (1.1.3)
     colorize (1.1.0)
     concurrent-ruby (1.3.6)
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     crass (1.0.6)
     date (3.5.1)
     docile (1.4.1)

--- a/deploy_pin.gemspec
+++ b/deploy_pin.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'colorize', '~> 1.1'
-  spec.add_dependency 'connection_pool', '~> 2.2'
+  spec.add_dependency 'connection_pool', '>= 2.2', '< 5'
   spec.add_dependency 'parallel', '~> 1.23'
   spec.add_dependency 'rails', '>= 7.0', '< 9.0'
   spec.add_dependency 'redis', '> 4.0'

--- a/lib/deploy_pin/version.rb
+++ b/lib/deploy_pin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeployPin
-  VERSION = '1.8.7'
+  VERSION = '1.8.8'
 end


### PR DESCRIPTION
## Summary
- Widen `connection_pool` dependency from `~> 2.2` to `>= 2.2, < 5` in `deploy_pin.gemspec`.
- The previous pin blocked consuming apps from upgrading Sidekiq beyond 8.0.1, since newer Sidekiq releases require `connection_pool >= 3.0`.
- The only in-repo usage of `connection_pool` (`ConnectionPool::Wrapper` in `DeploymentState`) is unaffected — the `Wrapper` API is unchanged between 2.x and 3.x.
- Bumped gem version to `1.8.8` and added a `CHANGELOG.md` entry, following this repo's existing convention.

## Test plan
- [x] `bundle lock --update connection_pool --conservative` to confirm only `connection_pool` (2.5.5 → 3.0.2) moves, with no unrelated dependency drift.
- [x] `bundle exec rubocop` on changed files — no offenses.
- [x] Full test suite (`bin/test`) run locally against Postgres + Redis: 64/65 passing. The one failure (`test_should_throw_exception_when_execution_time_is_equal_to_the_default_timeout`, a `Parallel::DeadWorker` crash) reproduces identically on unmodified `master`, confirming it's a pre-existing local-environment flake unrelated to this change.
- [x] Specifically verified `DeployPin::DeploymentState` (the only consumer of `ConnectionPool::Wrapper`) — all 4 tests pass against connection_pool 3.0.2.