### PR TITLE
Bump connection_pool from 2.2 to 3.0.2 (unblocks sidekiq >8.0 dependency lock)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     deploy_pin (1.8.7)
       colorize (~> 1.1)
-      connection_pool (~> 2.2)
+      connection_pool (~> 3.0.2)
       parallel (~> 1.23)
       rails (>= 7.0, < 9.0)
       redis (> 4.0)
@@ -94,7 +94,7 @@ GEM
     coderay (1.1.3)
     colorize (1.1.0)
     concurrent-ruby (1.3.6)
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     crass (1.0.6)
     date (3.5.1)
     docile (1.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     deploy_pin (1.8.7)
       colorize (~> 1.1)
-      connection_pool (~> 3.0.2)
+      connection_pool (>= 2.2, < 5)
       parallel (~> 1.23)
       rails (>= 7.0, < 9.0)
       redis (> 4.0)

--- a/deploy_pin.gemspec
+++ b/deploy_pin.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'colorize', '~> 1.1'
-  spec.add_dependency 'connection_pool', '~> 3.0.2'
+  spec.add_dependency 'connection_pool', '>= 2.2', '< 5'
   spec.add_dependency 'parallel', '~> 1.23'
   spec.add_dependency 'rails', '>= 7.0', '< 9.0'
   spec.add_dependency 'redis', '> 4.0'

--- a/deploy_pin.gemspec
+++ b/deploy_pin.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'colorize', '~> 1.1'
-  spec.add_dependency 'connection_pool', '~> 2.2'
+  spec.add_dependency 'connection_pool', '~> 3.0.2'
   spec.add_dependency 'parallel', '~> 1.23'
   spec.add_dependency 'rails', '>= 7.0', '< 9.0'
   spec.add_dependency 'redis', '> 4.0'


### PR DESCRIPTION
## What
Broaden `connection_pool` dependency to include newer versions, which sets it at the latest stable version (`3.02`).

## Why
 Unblocks `sidekiq` updates above `8.0.1` that were locked due to a newly added dependency on `connection_pool >= 3.0`.


Recent `sidekiq` versions updated their dependency on `connection_pool` to >= `3.0`, causing a dependency lock between `sidekiq >=8.1.1` and `dependency lock`.

 [Sidekiq 8.1.1 line that introduced the dependency lock](https://github.com/sidekiq/sidekiq/blob/v8.1.1/sidekiq.gemspec#L27).
## How
Broaden `connection_pool` versions in `Gemfile` to include newer stable versions.

No docs update necessary (grepped through the repo looking for `connection_pool`.
Gem builds successfully.

## Checklist
- [x] Tests
- [x] Docs
- [x] No breaking changes
